### PR TITLE
Add local cache for active super block

### DIFF
--- a/include/SmallBlockCommon.h
+++ b/include/SmallBlockCommon.h
@@ -14,10 +14,11 @@ typedef struct{
     NonBlockingStackBlock cleanSuperBlockStack;
     uint64_t *activeSuperBlock;
     uint64_t *activeSuperBlockBitmap;
+    uint64_t cachedBitmapContent;
     uint64_t *chunk;
     uint64_t superBlockUsage;
     uint64_t bitmapUsage;
-    uint64_t padding;
+    // uint64_t padding;
 }SmallBlockThreadInfo;
 
 typedef struct{


### PR DESCRIPTION
Having a local cache of active super block bitmap can avoid some of the atomic operations